### PR TITLE
Use GenerateDocumentationFile to expose doc comments to package consumers

### DIFF
--- a/src/dbup-sqlserver/AzureSqlConnectionManager.cs
+++ b/src/dbup-sqlserver/AzureSqlConnectionManager.cs
@@ -11,6 +11,13 @@ namespace DbUp.SqlServer;
 /// <summary>Manages an Azure Sql Server database connection.</summary>
 public class AzureSqlConnectionManager : DatabaseConnectionManager
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AzureSqlConnectionManager"/> class using a connection string and an Azure token credential.
+    /// </summary>
+    /// <param name="connectionString">The SQL connection string.</param>
+    /// <param name="tokenCredential">The Azure token credential used for authentication.</param>
+    /// <param name="resource">The resource URI for Azure SQL authentication.</param>
+    /// <param name="tenantId">Optional tenant ID for multi-tenant authentication scenarios.</param>
     public AzureSqlConnectionManager(
         string connectionString,
         TokenCredential tokenCredential,
@@ -34,6 +41,7 @@ public class AzureSqlConnectionManager : DatabaseConnectionManager
     {
     }
 
+    /// <inheritdoc/>
     public override IEnumerable<string> SplitScriptIntoCommands(string scriptContents)
     {
         var commandSplitter = new SqlCommandSplitter();

--- a/src/dbup-sqlserver/Helpers/TemporarySqlDatabase.cs
+++ b/src/dbup-sqlserver/Helpers/TemporarySqlDatabase.cs
@@ -26,6 +26,7 @@ namespace DbUp.SqlServer.Helpers
         /// Initializes a new instance of the <see cref="TemporarySqlDatabase"/> class.
         /// </summary>
         /// <param name="name">The name.</param>
+        /// <param name="instanceName">The name of the instance.</param>
         public TemporarySqlDatabase(string name, string instanceName) :
              this(new SqlConnectionStringBuilder($"Server={instanceName};Database={name};Trusted_connection=true;Pooling=false"))
         {

--- a/src/dbup-sqlserver/SqlConnectionManager.cs
+++ b/src/dbup-sqlserver/SqlConnectionManager.cs
@@ -26,6 +26,7 @@ namespace DbUp.SqlServer
              }))
         { }
 
+        /// <inheritdoc/>
         public override IEnumerable<string> SplitScriptIntoCommands(string scriptContents)
         {
             var commandSplitter = new SqlCommandSplitter();

--- a/src/dbup-sqlserver/SqlScriptExecutor.cs
+++ b/src/dbup-sqlserver/SqlScriptExecutor.cs
@@ -28,11 +28,13 @@ namespace DbUp.SqlServer
         {
         }
 
+        /// <inheritdoc/>
         protected override string GetVerifySchemaSql(string schema)
         {
             return string.Format(@"IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = N'{0}') Exec('CREATE SCHEMA [{0}]')", Schema);
         }
 
+        /// <inheritdoc/>
         protected override void ExecuteCommandsWithinExceptionHandler(int index, SqlScript script, Action executeCommand)
         {
             try

--- a/src/dbup-sqlserver/SqlServerObjectParser.cs
+++ b/src/dbup-sqlserver/SqlServerObjectParser.cs
@@ -9,6 +9,9 @@ namespace DbUp.SqlServer
     /// </summary>
     public class SqlServerObjectParser : SqlObjectParser
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SqlServerObjectParser"/> class.
+        /// </summary>
         public SqlServerObjectParser()
             : base("[", "]")
         {

--- a/src/dbup-sqlserver/SqlTableJournal.cs
+++ b/src/dbup-sqlserver/SqlTableJournal.cs
@@ -26,16 +26,19 @@ namespace DbUp.SqlServer
         {
         }
 
+        /// <inheritdoc/>
         protected override string GetInsertJournalEntrySql(string @scriptName, string @applied)
         {
             return $"insert into {FqSchemaTableName} (ScriptName, Applied) values ({@scriptName}, {@applied})";
         }
 
+        /// <inheritdoc/>
         protected override string GetJournalEntriesSql()
         {
             return $"select [ScriptName] from {FqSchemaTableName} order by [ScriptName]";
         }
 
+        /// <inheritdoc/>
         protected override string CreateSchemaTableSql(string quotedPrimaryKeyName)
         {
             return

--- a/src/dbup-sqlserver/dbup-sqlserver.csproj
+++ b/src/dbup-sqlserver/dbup-sqlserver.csproj
@@ -14,6 +14,7 @@
     <SignAssembly>true</SignAssembly>
     <RepositoryUrl>https://github.com/DbUp/dbup-sqlserver.git</RepositoryUrl>
     <PackageIcon>dbup-icon.png</PackageIcon>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(CI)' == 'true'">


### PR DESCRIPTION
# Checklist
- [x] I have read the [Contributing Guide](https://github.com/DbUp/DbUp/blob/master/CONTRIBUTING.md)
- [x] I have checked to ensure this does not introduce an unintended breaking changes
- [x] I have considered appropriate testing for my change

# Description
This PR closes #24. I started by adding the MSBuild property `GenerateDocumentationFile`. It caused 10 build failures, which are all fixed in this PR.

# Testing
Tested the change by publishing a prerelease package locally and consuming it in another code base.
### Screenshot before the change
<img width="434" height="111" alt="Image" src="https://github.com/user-attachments/assets/576052f2-8064-4b0c-a2b3-5ad1ceed6f3a" />

### Screenshot after the change
<img width="838" height="121" alt="Image" src="https://github.com/user-attachments/assets/5cf5ad65-2802-46b0-bd2e-cddac26ed2c1" />