### PR TITLE
Updated DbUp to 6.1.1 and patches to other libraries

### DIFF
--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\dbup-sqlserver\dbup-sqlserver.csproj"/>
-    <PackageReference Include="DbUp.Tests.Common" Version="6.0.15"/>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageReference Include="DbUp.Tests.Common" Version="6.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/src/dbup-sqlserver/dbup-sqlserver.csproj
+++ b/src/dbup-sqlserver/dbup-sqlserver.csproj
@@ -24,8 +24,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="dbup-core" Version="6.0.15" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.2" />
+    <PackageReference Include="dbup-core" Version="6.1.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request updates NuGet package dependencies in both the `src/Tests/Tests.csproj` and `src/dbup-sqlserver/dbup-sqlserver.csproj` files to newer versions, ensuring compatibility and access to the latest features and bug fixes.

Dependency version updates:

**Test project dependency updates:**

* Upgraded `DbUp.Tests.Common` from version 6.0.15 to 6.1.1 in `Tests.csproj`.
* Upgraded `Microsoft.NET.Test.Sdk` from version 18.0.0 to 18.0.1 in `Tests.csproj`.

**SQL Server project dependency updates:**

* Upgraded `dbup-core` from version 6.0.15 to 6.1.1 in `dbup-sqlserver.csproj`.
* Upgraded `Microsoft.Data.SqlClient` from version 6.1.2 to 6.1.4 in `dbup-sqlserver.csproj`.# Checklist
