### PR TITLE
Allow use of an existing SQL Connection

### DIFF
--- a/src/Tests/ApprovalFiles/NoPublicApiChanges.Run.approved.cs
+++ b/src/Tests/ApprovalFiles/NoPublicApiChanges.Run.approved.cs
@@ -1,4 +1,4 @@
-﻿[assembly: System.CLSCompliant(false)]
+[assembly: System.CLSCompliant(false)]
 [assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/DbUp/dbup-sqlserver.git")]
 [assembly: System.Runtime.InteropServices.ComVisible(false)]
 [assembly: System.Runtime.InteropServices.Guid("8190b40b-ac5b-414f-8a00-9b6a2c12b010")]
@@ -11,10 +11,14 @@ public static class SqlServerExtensions
 {
     public static DbUp.Builder.UpgradeEngineBuilder JournalToSqlTable(this DbUp.Builder.UpgradeEngineBuilder builder, string schema, string table) { }
     public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString) { }
+    public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema) { }
+    public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, Microsoft.Data.SqlClient.SqlConnection connection) { }
+    public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, Microsoft.Data.SqlClient.SqlConnection connection, string schema) { }
+    public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, DbUp.Engine.Transactions.IConnectionManager connectionManager, string schema = null) { }
+    public static void SqlDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString) { }
     public static void SqlDatabase(this DbUp.SupportedDatabasesForDropDatabase supported, string connectionString) { }
     public static bool SqlDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString) { }
     public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, DbUp.Engine.Transactions.IConnectionManager connectionManager, string schema = null) { }
-    public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema) { }
     public static void SqlDatabase(this DbUp.SupportedDatabasesForDropDatabase supported, string connectionString, int commandTimeout) { }
     public static bool SqlDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString, DbUp.SqlServer.AzureDatabaseEdition azureDatabaseEdition) { }
     public static bool SqlDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString, int commandTimeout) { }
@@ -47,6 +51,7 @@ namespace DbUp.SqlServer
     public class SqlConnectionManager : DbUp.Engine.Transactions.DatabaseConnectionManager
     {
         public SqlConnectionManager(string connectionString) { }
+        public SqlConnectionManager(SqlConnection connection) { }
         public override System.Collections.Generic.IEnumerable<string> SplitScriptIntoCommands(string scriptContents) { }
     }
     public class SqlScriptExecutor : DbUp.Support.ScriptExecutor

--- a/src/Tests/ApprovalFiles/NoPublicApiChanges.Run.approved.cs
+++ b/src/Tests/ApprovalFiles/NoPublicApiChanges.Run.approved.cs
@@ -10,15 +10,13 @@ public static class AzureSqlServerExtensions
 public static class SqlServerExtensions
 {
     public static DbUp.Builder.UpgradeEngineBuilder JournalToSqlTable(this DbUp.Builder.UpgradeEngineBuilder builder, string schema, string table) { }
-    public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString) { }
-    public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema) { }
     public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, Microsoft.Data.SqlClient.SqlConnection connection) { }
-    public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, Microsoft.Data.SqlClient.SqlConnection connection, string schema) { }
-    public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, DbUp.Engine.Transactions.IConnectionManager connectionManager, string schema = null) { }
-    public static void SqlDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString) { }
+    public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString) { }
     public static void SqlDatabase(this DbUp.SupportedDatabasesForDropDatabase supported, string connectionString) { }
     public static bool SqlDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString) { }
     public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, DbUp.Engine.Transactions.IConnectionManager connectionManager, string schema = null) { }
+    public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, Microsoft.Data.SqlClient.SqlConnection connection, string schema) { }
+    public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema) { }
     public static void SqlDatabase(this DbUp.SupportedDatabasesForDropDatabase supported, string connectionString, int commandTimeout) { }
     public static bool SqlDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString, DbUp.SqlServer.AzureDatabaseEdition azureDatabaseEdition) { }
     public static bool SqlDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString, int commandTimeout) { }
@@ -50,8 +48,8 @@ namespace DbUp.SqlServer
     }
     public class SqlConnectionManager : DbUp.Engine.Transactions.DatabaseConnectionManager
     {
+        public SqlConnectionManager(Microsoft.Data.SqlClient.SqlConnection connection) { }
         public SqlConnectionManager(string connectionString) { }
-        public SqlConnectionManager(SqlConnection connection) { }
         public override System.Collections.Generic.IEnumerable<string> SplitScriptIntoCommands(string scriptContents) { }
     }
     public class SqlScriptExecutor : DbUp.Support.ScriptExecutor

--- a/src/dbup-sqlserver/SqlConnectionManager.cs
+++ b/src/dbup-sqlserver/SqlConnectionManager.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Microsoft.Data.SqlClient;
 using DbUp.Engine.Transactions;
 using DbUp.Support;
@@ -15,15 +15,21 @@ namespace DbUp.SqlServer
         /// </summary>
         /// <param name="connectionString"></param>
         public SqlConnectionManager(string connectionString)
-             : base(new DelegateConnectionFactory((log, dbManager) =>
-             {
-                 var conn = new SqlConnection(connectionString);
+            : this(new SqlConnection(connectionString))
+        { }
 
-                 if (dbManager.IsScriptOutputLogged)
-                     conn.InfoMessage += (sender, e) => log.LogInformation($"{{0}}", e.Message);
+        /// <summary>
+        /// Manages Sql Database Connections using an existing connection.
+        /// </summary>
+        /// <param name="connection">The existing SQL connection to use.</param>
+        public SqlConnectionManager(SqlConnection connection)
+            : base(new DelegateConnectionFactory((log, dbManager) =>
+            {
+                if (dbManager.IsScriptOutputLogged)
+                    connection.InfoMessage += (sender, e) => log.LogInformation($"{{0}}", e.Message);
 
-                 return conn;
-             }))
+                return connection;
+            }))
         { }
 
         /// <inheritdoc/>

--- a/src/dbup-sqlserver/SqlServerExtensions.cs
+++ b/src/dbup-sqlserver/SqlServerExtensions.cs
@@ -35,6 +35,19 @@ public static class SqlServerExtensions
     /// Creates an upgrader for SQL Server databases.
     /// </summary>
     /// <param name="supported">Fluent helper type.</param>
+    /// <param name="connection">The sql connection.</param>
+    /// <returns>
+    /// A builder for a database upgrader designed for SQL Server databases.
+    /// </returns>
+    public static UpgradeEngineBuilder SqlDatabase(this SupportedDatabases supported, SqlConnection connection)
+    {
+        return SqlDatabase(supported, connection, null);
+    }
+
+    /// <summary>
+    /// Creates an upgrader for SQL Server databases.
+    /// </summary>
+    /// <param name="supported">Fluent helper type.</param>
     /// <param name="connectionString">The connection string.</param>
     /// <param name="schema">The SQL schema name to use. Defaults to 'dbo'.</param>
     /// <returns>
@@ -60,6 +73,20 @@ public static class SqlServerExtensions
         }
 
         return supported.SqlDatabase(new SqlConnectionManager(connectionString), schema);
+    }
+
+    /// <summary>
+    /// Creates an upgrader for SQL Server databases.
+    /// </summary>
+    /// <param name="supported">Fluent helper type.</param>
+    /// <param name="connection">The sql connection.</param>
+    /// <param name="schema">The SQL schema name to use. Defaults to 'dbo'.</param>
+    /// <returns>
+    /// A builder for a database upgrader designed for SQL Server databases.
+    /// </returns>
+    public static UpgradeEngineBuilder SqlDatabase(this SupportedDatabases supported, SqlConnection connection, string schema)
+    {
+        return SqlDatabase(new SqlConnectionManager(connection), schema);
     }
 
     /// <summary>


### PR DESCRIPTION
Pick of [#576](https://github.com/DbUp/DbUp/pull/576) into this repo and update to match latest code base

This pull request adds support for passing an existing `SqlConnection` to the `SqlConnectionManager` and `SqlServerExtensions.SqlDatabase` methods, enabling more flexible connection management when upgrading SQL Server databases. This enhancement allows consumers to reuse existing connections, which can be useful for advanced scenarios such as connection pooling or custom authentication.

**Support for existing SqlConnection:**

* Added a new constructor to `SqlConnectionManager` that accepts an existing `SqlConnection` object, allowing direct management of externally-created connections. [[1]](diffhunk://#diff-ca3aece64f9430707ed273367a9968bd2cc9d8d50e67d147cfdd92be9c26097bR18-R31) [[2]](diffhunk://#diff-f12901a5c86120379a005cbfccc4dba469d60f4c5a4901b641658103ae972d86R51)
* Added two new overloads to `SqlServerExtensions.SqlDatabase`:
  - One that accepts a `SqlConnection` (without schema), and
  - One that accepts a `SqlConnection` and a schema string, both returning an `UpgradeEngineBuilder` for SQL Server upgrades. [[1]](diffhunk://#diff-445b948753333a7d9f4d337a6e8a3479fd21baba4fc40572d002ba261f775267R34-R46) [[2]](diffhunk://#diff-445b948753333a7d9f4d337a6e8a3479fd21baba4fc40572d002ba261f775267R78-R91) [[3]](diffhunk://#diff-f12901a5c86120379a005cbfccc4dba469d60f4c5a4901b641658103ae972d86R13-R18)
