### PR TITLE
Accept a Func<SqlConnection> instead of a pre-created connection

### DIFF
--- a/src/Tests/ApprovalFiles/NoPublicApiChanges.Run.approved.cs
+++ b/src/Tests/ApprovalFiles/NoPublicApiChanges.Run.approved.cs
@@ -10,12 +10,12 @@ public static class AzureSqlServerExtensions
 public static class SqlServerExtensions
 {
     public static DbUp.Builder.UpgradeEngineBuilder JournalToSqlTable(this DbUp.Builder.UpgradeEngineBuilder builder, string schema, string table) { }
-    public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, Microsoft.Data.SqlClient.SqlConnection connection) { }
+    public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, System.Func<Microsoft.Data.SqlClient.SqlConnection> connectionFactory) { }
     public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString) { }
     public static void SqlDatabase(this DbUp.SupportedDatabasesForDropDatabase supported, string connectionString) { }
     public static bool SqlDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString) { }
     public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, DbUp.Engine.Transactions.IConnectionManager connectionManager, string schema = null) { }
-    public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, Microsoft.Data.SqlClient.SqlConnection connection, string schema) { }
+    public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, System.Func<Microsoft.Data.SqlClient.SqlConnection> connectionFactory, string schema) { }
     public static DbUp.Builder.UpgradeEngineBuilder SqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema) { }
     public static void SqlDatabase(this DbUp.SupportedDatabasesForDropDatabase supported, string connectionString, int commandTimeout) { }
     public static bool SqlDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString, DbUp.SqlServer.AzureDatabaseEdition azureDatabaseEdition) { }
@@ -48,7 +48,7 @@ namespace DbUp.SqlServer
     }
     public class SqlConnectionManager : DbUp.Engine.Transactions.DatabaseConnectionManager
     {
-        public SqlConnectionManager(Microsoft.Data.SqlClient.SqlConnection connection) { }
+        public SqlConnectionManager(System.Func<Microsoft.Data.SqlClient.SqlConnection> connectionFactory) { }
         public SqlConnectionManager(string connectionString) { }
         public override System.Collections.Generic.IEnumerable<string> SplitScriptIntoCommands(string scriptContents) { }
     }

--- a/src/dbup-sqlserver/SqlConnectionManager.cs
+++ b/src/dbup-sqlserver/SqlConnectionManager.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Microsoft.Data.SqlClient;
 using DbUp.Engine.Transactions;
@@ -15,22 +16,25 @@ namespace DbUp.SqlServer
         /// </summary>
         /// <param name="connectionString"></param>
         public SqlConnectionManager(string connectionString)
-            : this(new SqlConnection(connectionString))
-        { }
+            : this(() => new SqlConnection(connectionString))
+        {
+        }
 
         /// <summary>
         /// Manages Sql Database Connections using an existing connection.
         /// </summary>
-        /// <param name="connection">The existing SQL connection to use.</param>
-        public SqlConnectionManager(SqlConnection connection)
+        /// <param name="connectionFactory">A factory function that creates a new SQL connection.</param>
+        public SqlConnectionManager(Func<SqlConnection> connectionFactory)
             : base(new DelegateConnectionFactory((log, dbManager) =>
             {
+                var conn = connectionFactory();
                 if (dbManager.IsScriptOutputLogged)
-                    connection.InfoMessage += (sender, e) => log.LogInformation($"{{0}}", e.Message);
+                    conn.InfoMessage += (sender, e) => log.LogInformation("{0}", e.Message);
 
-                return connection;
+                return conn;
             }))
-        { }
+        {
+        }
 
         /// <inheritdoc/>
         public override IEnumerable<string> SplitScriptIntoCommands(string scriptContents)

--- a/src/dbup-sqlserver/SqlServerExtensions.cs
+++ b/src/dbup-sqlserver/SqlServerExtensions.cs
@@ -35,13 +35,13 @@ public static class SqlServerExtensions
     /// Creates an upgrader for SQL Server databases.
     /// </summary>
     /// <param name="supported">Fluent helper type.</param>
-    /// <param name="connection">The sql connection.</param>
+    /// <param name="connectionFactory">A func that create a new SqlConnection</param>
     /// <returns>
     /// A builder for a database upgrader designed for SQL Server databases.
     /// </returns>
-    public static UpgradeEngineBuilder SqlDatabase(this SupportedDatabases supported, SqlConnection connection)
+    public static UpgradeEngineBuilder SqlDatabase(this SupportedDatabases supported, Func<SqlConnection> connectionFactory)
     {
-        return SqlDatabase(supported, connection, null);
+        return SqlDatabase(supported, connectionFactory, null);
     }
 
     /// <summary>
@@ -79,14 +79,14 @@ public static class SqlServerExtensions
     /// Creates an upgrader for SQL Server databases.
     /// </summary>
     /// <param name="supported">Fluent helper type.</param>
-    /// <param name="connection">The sql connection.</param>
+    /// <param name="connectionFactory">A func that create a new SqlConnection</param>
     /// <param name="schema">The SQL schema name to use. Defaults to 'dbo'.</param>
     /// <returns>
     /// A builder for a database upgrader designed for SQL Server databases.
     /// </returns>
-    public static UpgradeEngineBuilder SqlDatabase(this SupportedDatabases supported, SqlConnection connection, string schema)
+    public static UpgradeEngineBuilder SqlDatabase(this SupportedDatabases supported, Func<SqlConnection> connectionFactory, string schema)
     {
-        return SqlDatabase(new SqlConnectionManager(connection), schema);
+        return SqlDatabase(new SqlConnectionManager(connectionFactory), schema);
     }
 
     /// <summary>


### PR DESCRIPTION
Fixed https://github.com/DbUp/dbup-sqlserver/issues/32

If we use a pre-created connection, then if `GetScriptsToExecute` and `PerformUpgrade` is called, an error occurs.

The user could still pass the same connection in via this factory if they really want.